### PR TITLE
Correct closing search results tag

### DIFF
--- a/content/search.md
+++ b/content/search.md
@@ -98,5 +98,5 @@ document.addEventListener("DOMContentLoaded", function() {
 </form>
 
 <div id="list_results">
-</ul>
+</div>
 


### PR DESCRIPTION
The closing tag should be `</div>` instead of `</ul>`. This gets corrected when JS loads, but nice to have clean HTML on load.